### PR TITLE
Added Djangozoom deployment badge

### DIFF
--- a/docs/badges/badge_djangozoom.rst
+++ b/docs/badges/badge_djangozoom.rst
@@ -1,0 +1,58 @@
+.. _badge_djangozoom:
+
+===============================
+DjangoZoom Deployment Badge
+===============================
+
+Synopsis!
+----------------
+
+To deploy a website is to put it up online as a live, working website for the world to see and use.
+
+This is a walkthrough of deploying the Django Poll tutorial files from Github.  We'll be deploying this project: https://github.com/pyladies/djangotutorial
+
+Length
+------
+15 minutes
+
+Prerequisites
+-------------
+
+You'll need a Djangozoom account.  Sign up at http://djangozoom.com and tell them that you need an account for the PyStar tutorial.
+
+Goals
+-----
+* be able to 
+
+Deploying from your repo
+------------------------
+
+Log into djangozoom.com.
+
+Go to My Projects. Click [Add a new project »]
+
+Under New Project > Repo url, enter something like git@github.com:pyladies/djangotutorial.git
+
+Click [Checkout code & continue]
+
+Check that your configuration matches your project, making changes if needed. (For https://github.com/pyladies/djangotutorial, the default values work as-is.)
+
+Scroll all the way down. Click [Deploy project]
+
+It should say "Working..." Wait for it to finish.  It should change to "Job succeeded, deployed at http://p00000333.djangozoom.net".
+
+(Note: if it fails, check your configuration. Ask for help in #djangozoom - they're nice)
+
+Open whatever URL you were given in a new browser tab.  Congrats, your project is now live on the web!
+
+Domain names
+------------
+
+To set your domain name, click [Custom Hostnames] and follow the instructions.
+
+Accessing the Django admin
+--------------------------
+
+Finally, to access your site's Django admin, click [Create Superuser].  Enter a password that you'll be able to remember and click [Create Superuser Account].
+
+Then go to your site's Django admin (something like http://p00000333.djangozoom.net/admin/) and log in with your superuser name/password.

--- a/docs/badges/index.rst
+++ b/docs/badges/index.rst
@@ -21,6 +21,7 @@ List of Badges!
     badge_LPTHW_2
     badge_turtle
     badge_djangoapp
+    badge_djangozoom
     badge_python_tutorial
     badge_colorwall
     badge_edit_html


### PR DESCRIPTION
Teaching Django beginners how to deploy their first websites in an easy way is empowering.  I've added a Djangozoom deployment badge to the list of badges, right below the Django app badge.
